### PR TITLE
Bugfix + minimizable chat

### DIFF
--- a/public/chat.css
+++ b/public/chat.css
@@ -38,13 +38,37 @@
   box-shadow: 0px 0px 4px rgba(0, 0, 0, .3);
   border-radius: 3px 3px 0px 0px;
   -moz-border-radius: 3px 3px 0px 0px;
-  -webkit-border-radius: 3px 3px 0px 0px;  
+  -webkit-border-radius: 3px 3px 0px 0px;
 
-  height: 300px;
   width: 240px;
+}
 
+.chat-widget-body {
+  height: 300px;
   display: flex;
   flex-direction: column;
+}
+
+.chat-widget.minimized {
+  height: auto;
+}
+
+.chat-widget.minimized .chat-widget-body {
+  display: none;
+}
+
+.chat-widget.minimized .close {
+  display: none;
+}
+
+.chat-widget-header .unread {
+  font-size: 12px;
+  padding: 0 6px;
+  background: #ff1a1a;
+  color: white;
+  border-radius: 12px;
+  vertical-align: middle;
+  cursor: pointer;
 }
 
 .chat-widget-header {

--- a/public/chat.js
+++ b/public/chat.js
@@ -86,7 +86,7 @@
           hideChatButton();
         });
         document.body.appendChild(div);
-        if(localStorage.getItem("chat-history")) {
+        if(currentChatToken()) {
           showChatWidget();
           hideChatButton();
           sendResumed();
@@ -272,6 +272,7 @@
     } else if (config.welcome_message) {
       // No chat session yet? Send a welcome message
       setTimeout(function(){
+        localStorage.removeItem("chat-history");
         appendRemoteMessage(null, config.welcome_message);
         addMessageToHistory("remote", config.welcome_message);
       }, 900);

--- a/public/chat.js
+++ b/public/chat.js
@@ -8,7 +8,9 @@
     send: base_url+"/chat/send",
     listen: base_url+"/streaming/sub",
     quit: base_url+"/chat/quit",
-    resumed: base_url+"/chat/resumed"
+    resumed: base_url+"/chat/resumed",
+    placeholder: "Type a message, press enter to send...",
+    welcome_message: "Hi visitor, tell me, who are you and what can I do for you?"
   };
 
   function ready(fn) {
@@ -179,7 +181,7 @@
         '<ul></ul>' +
       '</div>' +
       '<div class="chat-widget-input">' +
-        '<textarea name="chat-widget-message" disabled placeholder="Type a message, press enter to send..."></textarea>'
+        '<textarea name="chat-widget-message" disabled placeholder="'+config.placeholder+'"></textarea>'
       '</div>'
       ;
     document.body.appendChild(div);
@@ -200,7 +202,14 @@
     if(currentChatToken()) {
       loadMessageHistory();
       listenForMessages(currentChatChannel());
+    } else if (config.welcome_message) {
+      // No chat session yet? Send a welcome message
+      setTimeout(function(){
+        appendRemoteMessage(null, config.welcome_message);
+        addMessageToHistory("remote", config.welcome_message);
+      }, 900);
     }
+
     document.querySelector(".chat-widget-input textarea").disabled = false;
   }
 

--- a/public/chat.js
+++ b/public/chat.js
@@ -160,8 +160,8 @@
   }
 
   function hideChatWidget() {
-    document.querySelector('.chat-widget').classList.add("hidden");
-    document.querySelector('.chat-widget').innerHTML = '';
+    var widget = document.querySelector('.chat-widget');
+    widget.parentNode.removeChild(widget);
   }
 
   function showChatWidget() {
@@ -214,10 +214,9 @@
   }
 
   function closeChatWidget() {
-    sendQuit();
-    localStorage.removeItem("chat-token");
-    localStorage.removeItem("chat-channel");
-    localStorage.removeItem("chat-history");
+    if(currentChatToken()) {
+      sendQuit();
+    }
     hideChatWidget();
     showChatButton();
   }
@@ -263,7 +262,9 @@
     post(config.quit, {
       token: currentChatToken()
     }, function(response){
-
+      localStorage.removeItem("chat-token");
+      localStorage.removeItem("chat-channel");
+      localStorage.removeItem("chat-history");
     });
   }
 

--- a/public/chat.js
+++ b/public/chat.js
@@ -107,6 +107,26 @@
       var msg = JSON.parse(e.data);
       appendRemoteMessage(msg.data.nick, msg.data.text);
       addMessageToHistory("remote", msg.data.text);
+      if(document.querySelector('.chat-widget').classList.contains('minimized')) {
+        incrementUnreadCount();
+      }
+    }
+  }
+
+  function incrementUnreadCount() {
+    var unread = document.querySelector('.chat-widget .unread');
+    if (!unread) {
+      unread = document.createElement('span');
+      unread.classList.add('unread');
+      unread.innerText = 1;
+      unread.addEventListener("click", function(evt){
+        evt.preventDefault();
+        toggleMinMaxChatWidget();
+      });
+      var right = document.querySelector('.chat-widget-header .right');
+      right.insertBefore(unread, right.firstChild);
+    } else {
+      unread.innerText = parseInt(unread.innerText) + 1;
     }
   }
 
@@ -159,6 +179,27 @@
     document.querySelector('.chat-button').classList.remove("hidden");
   }
 
+  function toggleMinMaxChatWidget() {
+      var button = document.querySelector(".chat-widget .minimize");
+      if (button.innerHTML == '–') {
+        button.innerHTML = '+';
+        minimizeChatWidget();
+      } else {
+        button.innerHTML = '–';
+        maximizeChatWidget();
+      }
+  }
+
+  function minimizeChatWidget() {
+    document.querySelector('.chat-widget').classList.add("minimized");
+  }
+
+  function maximizeChatWidget() {
+    document.querySelector('.chat-widget').classList.remove("minimized");
+    var unread = document.querySelector('.chat-widget .unread');
+    if (unread) unread.parentNode.removeChild(unread);
+  }
+
   function hideChatWidget() {
     var widget = document.querySelector('.chat-widget');
     widget.parentNode.removeChild(widget);
@@ -174,15 +215,17 @@
           config.admin_name +
         '</span>' +
         '<span class="right">' +
+          '<a href="#" class="minimize">–</a>' +
           '<a href="#" class="close">&times;</a>' +
         '</span>' +
       '</div></div>' +
+      '<div class="chat-widget-body">' +
       '<div class="chat-widget-messages">' +
         '<ul></ul>' +
       '</div>' +
       '<div class="chat-widget-input">' +
         '<textarea name="chat-widget-message" disabled placeholder="'+config.placeholder+'"></textarea>'
-      '</div>'
+      '</div></div>'
       ;
     document.body.appendChild(div);
     document.querySelector(".chat-widget-input textarea").addEventListener("keydown", function(evt){
@@ -196,6 +239,11 @@
     document.querySelector(".chat-widget .close").addEventListener("click", function(evt){
       evt.preventDefault();
       closeChatWidget();
+    });
+
+    document.querySelector(".chat-widget .minimize").addEventListener("click", function(evt){
+      evt.preventDefault();
+      toggleMinMaxChatWidget();
     });
 
     // Request a chat session token or use the one that already exists

--- a/public/chat.js
+++ b/public/chat.js
@@ -72,7 +72,7 @@
       request.onerror = err;
     }
 
-    request.send();    
+    request.send();
   }
 
   ready(function(){
@@ -237,15 +237,15 @@
       });
     }
   }
-  
+
   function sendCurrentMessage() {
     getChatToken(function(){
       var input = document.querySelector(".chat-widget-input textarea");
       var text = input.value;
       input.value = "";
-  
+
       var li = appendMyMessage(text);
-  
+
       post(config.send, {
         token: currentChatToken(),
         text: text
@@ -254,7 +254,7 @@
         addMessageToHistory("my", text);
       }, function(err) {
         li.classList.add("error");
-      });      
+      });
     });
     return false;
   }


### PR DESCRIPTION
I think this PR is best reviewed per commit.

The first one adds an option to send a message as soon as the visitor opens the window. The message will not be send to you, but it’s a nice way of explaining that it is in fact a chat, and that we do not know their identity yet.

The second commit fixes some whitespace, because my editor does that. Meh.

The third commit is an actual bugfix. When you open and close and open and close the window, a new session is created, but since the window is not actually destroyed, something lives on. Anyway, check the commit for more details.

The fourth commit adds a minimized state to the chat window. In my own experience, I wanted to dismiss the chat. As a visitor, I did not expect to throw all my history out by just closing that window. Adding a minimized state, makes it clearer that you actually close the session with the ‘x’.

When the window is closed, the line is still open, so the remote party can still send messages. I added a little red badge with an unread-count which only shows if the window is closed.

![schermafbeelding 2017-07-30 om 14 59 42](https://user-images.githubusercontent.com/16517999/28753728-079360fe-7539-11e7-92e6-686d4213003a.jpg)


Hope you like this!